### PR TITLE
Add sign out URL setting

### DIFF
--- a/assets/components/App.js
+++ b/assets/components/App.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter as Router, Link, Redirect, Route, Switch } from "react-router-dom";
 import "semantic-ui-css/semantic.css";
-import { Container, Dimmer, Loader, Menu } from "semantic-ui-react";
+import { Container, Dimmer, Dropdown, Loader, Menu } from "semantic-ui-react";
 
 import api from "../api";
 import store from "../redux/store";
@@ -19,14 +19,17 @@ import ProjectPage from "./pages/project/ProjectPage";
 class App extends Component {
   state = {
     isInitializing: true,
+    settings: {},
     user: null,
   };
 
   componentDidMount() {
-    api
-      .get(`/profile/`)
-      .then(data => {
-        this.setState({ user: data.user });
+    Promise.all([api.get("/profile/"), api.get("/settings/")])
+      .then(([profileData, settingsData]) => {
+        this.setState({
+          user: profileData.user,
+          settings: settingsData.settings,
+        });
       })
       .finally(() => {
         this.setState({ isInitializing: false });
@@ -34,7 +37,7 @@ class App extends Component {
   }
 
   render() {
-    const { isInitializing, user } = this.state;
+    const { isInitializing, settings, user } = this.state;
 
     if (isInitializing) {
       return (
@@ -59,9 +62,19 @@ class App extends Component {
                 <Menu.Item>
                   <Link to="/projects/">Projects</Link>
                 </Menu.Item>
-                <Menu.Item position="right">
-                  {user ? user.username : <a href="/signin/">Sign in</a>}
-                </Menu.Item>
+                <Menu.Menu position="right">
+                  {settings.sign_out_url ? (
+                    <Dropdown item text={user.username}>
+                      <Dropdown.Menu>
+                        <Dropdown.Item as="a" href={settings.sign_out_url}>
+                          Sign out
+                        </Dropdown.Item>
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  ) : (
+                    <Menu.Item position="right">{user.username}</Menu.Item>
+                  )}
+                </Menu.Menu>
               </Container>
             </Menu>
 

--- a/curation_portal/settings/base.py
+++ b/curation_portal/settings/base.py
@@ -153,3 +153,5 @@ REST_FRAMEWORK = {"DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.Dja
 # Curation portal app settings
 
 CURATION_PORTAL_AUTH_HEADER = os.getenv("CURATION_PORTAL_AUTH_HEADER", "REMOTE_USER")
+
+CURATION_PORTAL_SIGN_OUT_URL = os.getenv("CURATION_PORTAL_SIGN_OUT_URL", None)

--- a/curation_portal/urls.py
+++ b/curation_portal/urls.py
@@ -8,6 +8,7 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 from django.urls import path
 from django.views.generic import TemplateView
 
+from curation_portal.views.app_settings import ApplicationSettingsView
 from curation_portal.views.curate_variant import CurateVariantView
 from curation_portal.views.export_results import ExportProjectResultsView
 from curation_portal.views.projects import AssignedProjectsView, OwnedProjectsView
@@ -43,6 +44,7 @@ urlpatterns = [
         DEFAULT_TEMPLATE_VIEW,
         name="curate-variant",
     ),
+    path("api/settings/", ApplicationSettingsView.as_view(), name="api-app-settings"),
     path("api/assignments/", AssignedProjectsView.as_view(), name="api-assignments"),
     path("api/projects/", OwnedProjectsView.as_view(), name="api-projects"),
     path("api/projects/create/", CreateProjectView.as_view(), name="api-create-project"),

--- a/curation_portal/views/app_settings.py
+++ b/curation_portal/views/app_settings.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class ApplicationSettingsView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        return Response({"settings": {"sign_out_url": settings.CURATION_PORTAL_SIGN_OUT_URL}})

--- a/docker/oauth-proxy/docker-compose.yml
+++ b/docker/oauth-proxy/docker-compose.yml
@@ -23,3 +23,4 @@ services:
   app:
     environment:
       - CURATION_PORTAL_AUTH_HEADER=HTTP_X_FORWARDED_EMAIL
+      - CURATION_PORTAL_SIGN_OUT_URL=/oauth2/sign_out

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,3 +53,9 @@ The variant curation portal can be configured using the following environment va
   The curation portal uses Django's [RemoteUserMiddleware](https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/)
   for authentication. This setting controls the header from which the authenticated user's username is read.
   Defaults to `REMOTE_USER`.
+
+- `CURATION_PORTAL_SIGN_OUT_URL`
+
+  Since authentication is handled externally, the curation portal cannot sign out a user. This setting tells the
+  curation portal where to direct a user so that they can sign out of whatever system is handling authentication
+  for the portal.

--- a/tests/test_app_settings_view.py
+++ b/tests/test_app_settings_view.py
@@ -1,0 +1,30 @@
+# pylint: disable=redefined-outer-name,unused-argument
+import pytest
+from rest_framework.test import APIClient
+
+from curation_portal.models import User
+
+pytestmark = pytest.mark.django_db  # pylint: disable=invalid-name
+
+
+@pytest.fixture(scope="module")
+def db_setup(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        user = User.objects.create(username="user")
+        yield
+        user.delete()
+
+
+def test_app_settings_requires_authentication(db_setup):
+    client = APIClient()
+    response = client.get("/api/settings/")
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize("sign_out_url", [None, "/sign_out"])
+def test_app_settings_returns_configured_sign_out_url(db_setup, settings, sign_out_url):
+    settings.CURATION_PORTAL_SIGN_OUT_URL = sign_out_url
+    client = APIClient()
+    client.force_authenticate(User.objects.get(username="user"))
+    response = client.get("/api/settings/").json()
+    assert response["settings"]["sign_out_url"] == sign_out_url


### PR DESCRIPTION
Since authentication is handled externally through [RemoteUserMiddleware](https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/), the curation portal cannot sign out a user. This adds a setting for a sign out URL, which tells the curation portal where to direct a user so that they can sign out of whatever system is handling authentication for the portal. If a sign out URL is configured, it is shown in a dropdown menu from the current user's username in the top bar.