### PR TITLE
Install database adapter using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Install dependencies
-RUN apk add --no-cache py3-psycopg2
-# psycopg2 installed through apk is placed in a different directory than
-# packages installed with pip
-ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3.6/site-packages"
+RUN apk add --virtual build-deps gcc musl-dev python3-dev \
+  && apk add --no-cache postgresql-dev \
+  && pip install --no-cache-dir psycopg2 \
+  && apk del build-deps
 
 RUN pip install --no-cache-dir gunicorn==19.9.0
 


### PR DESCRIPTION
Currently, the [psycopg2](https://pypi.org/project/psycopg2/) database adapter is installed with `apk` from the `py3-psycopg2` package. This was done to avoid having to install the dependencies required to build it from source. However, in the latest version of the `python:3.6-alpine` image `py3-psycopg2` installs into `site-packages` for Python 3.7 instead of 3.6.

This changes the Docker build to install psycopg2 using `pip` instead of `apk`. apk's [virtual packages](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#virtual-packages) are used to clean up build related dependencies after they're no longer needed.